### PR TITLE
Sp 3421

### DIFF
--- a/Block/Catalog/Product/View/PaymentOptions.php
+++ b/Block/Catalog/Product/View/PaymentOptions.php
@@ -81,7 +81,7 @@ class PaymentOptions extends \Magento\Framework\View\Element\Template
     {
         $curInstallment = 10;
         $amountPerInstallment ='';
-        $totalAmount = $this->getCurrentProduct()->getPriceInfo()->getPrice('final_price')->getValue();
+        $totalAmount = $this->getCurrentProduct()->getFinalPrice();
         $InstallmentNo = $this->configHelper->getConfigData('installment_no');
         if($InstallmentNo){
             $curInstallment = $InstallmentNo;

--- a/Controller/Latitude/AbstractLatitude.php
+++ b/Controller/Latitude/AbstractLatitude.php
@@ -329,6 +329,26 @@ abstract class AbstractLatitude extends AppAction  implements RedirectLoginInter
     {
         return 'start';
     }
+
+    /**
+     * Log payload callback
+     *
+     * @param mixed $payload
+     * @return void
+     */
+    public function logCallback($payload)
+    {
+        $quote = $this->_getQuote();
+        if (
+            $payload &&
+            $quote &&
+            $quote->getPayment()->getMethod() &&
+            $this->configHelper->getConfigData('logging',$quote->getStoreId(),$quote->getPayment()->getMethod())
+        ) {
+            $this->logger->info('Order Status (RESPONSE): ', $payload);
+        }
+    }
+
     /**
      * @inheritdoc
      */

--- a/Controller/Latitude/AbstractLatitude/Cancel.php
+++ b/Controller/Latitude/AbstractLatitude/Cancel.php
@@ -19,6 +19,9 @@ class Cancel extends \Latitude\Payment\Controller\Latitude\AbstractLatitude
     {
         try {
             $this->_initToken(false);
+            // Log payload callback
+            $post = $this->getRequest()->getParams();
+            $this->logCallback($post);
             // if there is an order - cancel it
             /** @noinspection PhpUndefinedMethodInspection */
             $orderId = $this->_getCheckoutSession()->getLastOrderId();
@@ -36,8 +39,8 @@ class Cancel extends \Latitude\Payment\Controller\Latitude\AbstractLatitude
 
             } else {
                 $this->logger->error('There was an error with your payment, please try again or select other payment method');
-
             }
+
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $this->messageManager->addExceptionMessage($e, $e->getMessage());
         } catch (\Exception $e) {

--- a/Controller/Latitude/AbstractLatitude/Fail.php
+++ b/Controller/Latitude/AbstractLatitude/Fail.php
@@ -23,6 +23,9 @@ class Fail extends GetToken
     {
         try {
             $this->_initToken(false);
+            // Log payload callback
+            $post = $this->getRequest()->getParams();
+            $this->logCallback($post);
             // if there is an order - cancel it
             /** @noinspection PhpUndefinedMethodInspection */
             $orderId = $this->_getCheckoutSession()->getLastOrderId();
@@ -46,6 +49,7 @@ class Fail extends GetToken
                     __('Checkout has been canceled.')
                 );
             }
+
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $this->messageManager->addExceptionMessage($e, $e->getMessage());
         } catch (\Exception $e) {

--- a/Controller/Latitude/AbstractLatitude/Placeorder.php
+++ b/Controller/Latitude/AbstractLatitude/Placeorder.php
@@ -23,10 +23,12 @@ class Placeorder extends \Latitude\Payment\Controller\Latitude\AbstractLatitude
     public function execute()
     {
         $post = $this->getRequest()->getParams();
+
         if($post && $post["result"] != "COMPLETED"){
-            $this->_redirect('*/*/cancel');
+            $this->_redirect('*/*/cancel',['_query' => $post]);
             return;
         }
+
         try {
 
             $this->_initCheckout();
@@ -35,6 +37,8 @@ class Placeorder extends \Latitude\Payment\Controller\Latitude\AbstractLatitude
 
             $this->checkout->returnFromLatitude($tokenId);
 
+            // Log payload callback
+            $this->logCallback($post);
 
             $this->checkout->place($post["token"]);
 
@@ -77,7 +81,6 @@ class Placeorder extends \Latitude\Payment\Controller\Latitude\AbstractLatitude
         }  catch (LocalizedException $e) {
             $this->processException($e, $e->getRawMessage());
         } catch (\Exception $e) {
-
             $this->processException($e, 'We can\'t place the order.');
         }
     }
@@ -96,6 +99,4 @@ class Placeorder extends \Latitude\Payment\Controller\Latitude\AbstractLatitude
 
         $this->_redirect('checkout?cancel', ['_fragment' => 'payment']);
     }
-
-
 }


### PR DESCRIPTION
Please help me review Merge Request for this task
https://jira.magebinary.com/browse/SP-3421

User story
When Magento 2 logs are enabled It is logging payload request, initially create purchase response, however, it is not logging the final response from the API(success/fail response).
Also, I want to enable response signature validation logs as well. so when the response is validated I want to see the logs if it says approved, declined(response signature).

Test result
Work as expected.
Example output in log file
[2021-02-09 08:59:14] mxLogger.INFO: Order Status (RESPONSE): {"token":"72399809-4721-4bab-9f0c-1a1d57fa9e13","reference":"000000008","message":"Declined - Please contact Genoapay.","result":"COMPLETED","signature":"9044b7dac15a148f704edc4b42adf79e7e168a5b614be71209d5663c266ec81e"} []
Thanks